### PR TITLE
Chat sessions + history (multi-session per project, ipio-style)

### DIFF
--- a/apps/api/drizzle/0001_bored_iron_lad.sql
+++ b/apps/api/drizzle/0001_bored_iron_lad.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `chat_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`workspace_id` text NOT NULL,
+	`title` text DEFAULT 'New chat' NOT NULL,
+	`message_count` integer DEFAULT 0 NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`last_message_at` integer
+);
+--> statement-breakpoint
+CREATE INDEX `idx_chat_sessions_project` ON `chat_sessions` (`project_id`,`updated_at`);

--- a/apps/api/drizzle/meta/0001_snapshot.json
+++ b/apps/api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,156 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2144b622-4eb3-4016-9be8-c392f65d5645",
+  "prevId": "a29c5ad5-6345-4ebb-9bbe-565bfe57ad94",
+  "tables": {
+    "chat_sessions": {
+      "name": "chat_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New chat'"
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_chat_sessions_project": {
+          "name": "idx_chat_sessions_project",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_projects_ws": {
+          "name": "idx_projects_ws",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780415883219,
       "tag": "0000_harsh_tiger_shark",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1780437421416,
+      "tag": "0001_bored_iron_lad",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/agents/orchestrator.ts
+++ b/apps/api/src/agents/orchestrator.ts
@@ -1,10 +1,13 @@
 import { Think } from '@cloudflare/think';
-import type { TurnContext as ThinkTurnContext } from '@cloudflare/think';
+import type { TurnContext as ThinkTurnContext, TurnConfig } from '@cloudflare/think';
 import type { Connection, ConnectionContext } from 'agents';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import type { LanguageModel, ToolSet } from 'ai';
+import type { LanguageModel, ModelMessage, ToolSet } from 'ai';
+import { drizzle } from 'drizzle-orm/d1';
+import { sql } from 'drizzle-orm';
 import type { Env } from '../index';
 import { verifyRoomToken } from '../lib/room-token';
+import { chatSessions as chatSessionsTable } from '../db/schema';
 import { createOrchestratorTools, type TurnContext } from './orchestrator-tools';
 
 const SYSTEM_PROMPT = `You are a geometry-node scene assistant for a Three.js node-graph editor.
@@ -27,41 +30,39 @@ export class Orchestrator extends Think<Env> {
   /**
    * Authorized projectId bound from the validated room token in `onConnect`.
    * Populated once per connection; `undefined` until authentication succeeds.
-   * Because turns are serialized by Think and each Durable Object instance
-   * handles one project (instance name = projectId), a single in-memory field
-   * is safe for the lifetime of the DO instance.
+   *
+   * SECURITY: this value comes from the validated JWT, never from client body.
+   * Instance name is now `${projectId}:${sessionId}` — the projectId is the
+   * portion BEFORE the first colon.
    */
   authorizedProjectId: string | undefined;
 
   /**
-   * Authorized userId from the validated room token. Stored alongside
-   * authorizedProjectId for future per-user auditing / rate-limiting.
+   * Authorized sessionId parsed from the DO instance name (`${projectId}:${sessionId}`).
+   * Used as the D1 `chat_sessions` row key. Not security-sensitive — a user can
+   * only mint a room token for a project they own, and tools only touch that project.
+   */
+  authorizedSessionId: string | undefined;
+
+  /**
+   * Authorized userId from the validated room token.
    */
   authorizedUserId: string | undefined;
 
   /**
    * Per-turn context captured from the chat request body in `beforeTurn`.
-   * The chat client (Task 3) sends `{ projectId, catalog }`; Think surfaces
-   * it as `TurnContext.body`. Tools read this lazily via `getContext`.
-   *
    * Turns are serialized by Think, so a single in-memory field per turn is safe.
    */
   private turnContext: TurnContext = {};
 
   /**
    * Called by the agents SDK when a WebSocket client connects.
-   * Mirrors EditorRoom.onConnect: validates the room token from ?token=...
-   * in the WS upgrade URL before allowing the connection.
    *
-   * Token payload must satisfy:
-   *   - valid HMAC-SHA256 signature (verifyRoomToken throws otherwise)
-   *   - not expired (verifyRoomToken throws otherwise)
-   *   - payload.projectId === this.name (the DO instance name = projectId,
-   *     set by the router in Task 3 via `name: projectId`)
+   * Instance name is now `${projectId}:${sessionId}`. The dock connects with
+   * `name: \`${projectId}:${sessionId}\``. We parse the projectId from the name
+   * and validate it against the token payload.
    *
    * On failure the connection is closed with code 4001 (mirroring EditorRoom).
-   * On success the authorized identity is stashed in instance fields so that
-   * `beforeTurn` / `resolveRoom` can use it instead of the client-supplied body.
    */
   async onConnect(connection: Connection, ctx: ConnectionContext): Promise<void> {
     const url = new URL(ctx.request.url);
@@ -80,14 +81,22 @@ export class Orchestrator extends Think<Env> {
       return;
     }
 
-    if (payload.projectId !== this.name) {
+    // Parse projectId and sessionId from the instance name.
+    // Format: "${projectId}:${sessionId}" (sessionId may be absent for legacy
+    // bare-projectId names — we still accept those for backward compat).
+    const colonIdx = this.name.indexOf(':');
+    const projectId = colonIdx >= 0 ? this.name.slice(0, colonIdx) : this.name;
+    const sessionId = colonIdx >= 0 ? this.name.slice(colonIdx + 1) : undefined;
+
+    if (payload.projectId !== projectId) {
       connection.close(4001, 'Token project mismatch');
       return;
     }
 
     // Token is valid — stash the authorized identity. Tools use
     // this.authorizedProjectId (never ctx.body.projectId) to resolve the Room.
-    this.authorizedProjectId = payload.projectId;
+    this.authorizedProjectId = projectId;
+    this.authorizedSessionId = sessionId;
     this.authorizedUserId = payload.userId;
   }
 
@@ -105,21 +114,17 @@ export class Orchestrator extends Think<Env> {
   }
 
   /**
-   * Capture the per-turn context before inference runs.
+   * Capture the per-turn context before inference runs, and kick off a D1
+   * session-index upsert in the background.
    *
    * SECURITY: `projectId` is sourced exclusively from `this.authorizedProjectId`
-   * (bound to the validated room token in `onConnect`), NOT from the client-
-   * supplied request body. If the body sends a different projectId, it is silently
-   * ignored — the token is the authoritative source.
+   * (bound to the validated room token in `onConnect`), NOT from the client body.
    *
-   * `catalog` is NOT security-sensitive (it's a UI hint about node types), so it
-   * is still accepted from `ctx.body` as before.
-   *
-   * `ctx.body` carries the custom fields the chat client put in the request body
-   * (see @cloudflare/think TurnContext: "Custom body fields from the client
-   * request").
+   * `ctx.messages` (from ThinkTurnContext, per the @cloudflare/think TurnContext
+   * interface) contains the assembled ModelMessage[] including the latest user
+   * message — we extract its text for auto-titling.
    */
-  beforeTurn(ctx: ThinkTurnContext): void {
+  beforeTurn(ctx: ThinkTurnContext): TurnConfig | void {
     const body = (ctx.body ?? {}) as Record<string, unknown>;
 
     // projectId: always from token, never from body.
@@ -132,6 +137,13 @@ export class Orchestrator extends Think<Env> {
           ? JSON.stringify(body.catalog)
           : undefined;
     this.turnContext = { projectId, catalog };
+
+    // Extract the first user message text for auto-titling.
+    // ctx.messages is the assembled ModelMessage[] (from ThinkTurnContext.messages).
+    const firstUserText = extractFirstUserText(ctx.messages);
+
+    // Fire-and-forget the D1 upsert — must not block the model response.
+    this.ctx.waitUntil(this.touchSession(firstUserText));
   }
 
   getTools(): ToolSet {
@@ -140,4 +152,91 @@ export class Orchestrator extends Think<Env> {
       getContext: () => this.turnContext,
     });
   }
+
+  /**
+   * Upsert the D1 `chat_sessions` row for the current session so the session
+   * list shows accurate metadata (messageCount, lastMessageAt, title).
+   *
+   * - If the row exists: increment messageCount, bump updatedAt / lastMessageAt,
+   *   and update title only when it is still the default 'New chat'.
+   * - If the row does not exist (session created lazily): INSERT with all fields.
+   * - Wrapped in try/catch — a D1 hiccup must NOT break the chat turn.
+   */
+  private async touchSession(firstUserText?: string): Promise<void> {
+    if (!this.authorizedSessionId || !this.authorizedProjectId || !this.authorizedUserId) {
+      return;
+    }
+
+    const sessionId = this.authorizedSessionId;
+    const projectId = this.authorizedProjectId;
+    const userId = this.authorizedUserId;
+    const now = Date.now();
+    const derivedTitle = firstUserText
+      ? firstUserText.slice(0, 60).trim()
+      : 'New chat';
+
+    try {
+      const db = drizzle(this.env.DB);
+
+      await db
+        .insert(chatSessionsTable)
+        .values({
+          id: sessionId,
+          projectId,
+          workspaceId: userId,
+          title: derivedTitle !== 'New chat' ? derivedTitle : 'New chat',
+          messageCount: 1,
+          createdAt: now,
+          updatedAt: now,
+          lastMessageAt: now,
+        })
+        .onConflictDoUpdate({
+          target: chatSessionsTable.id,
+          set: {
+            messageCount: sql`${chatSessionsTable.messageCount} + 1`,
+            updatedAt: now,
+            lastMessageAt: now,
+            // Only overwrite the title when it is still the default placeholder.
+            title: sql`CASE WHEN ${chatSessionsTable.title} = 'New chat' AND ${derivedTitle !== 'New chat' ? 1 : 0} THEN ${derivedTitle} ELSE ${chatSessionsTable.title} END`,
+          },
+        });
+    } catch (err) {
+      console.error('[orchestrator] touchSession D1 upsert failed', {
+        sessionId,
+        error: String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Extract the text of the last user message from the assembled ModelMessage[].
+ * Returns undefined when no user text is present.
+ *
+ * ModelMessage is the AI SDK's internal format: role + content.
+ * content may be a string or an array of parts with type 'text' | 'image' | etc.
+ */
+function extractFirstUserText(messages: ModelMessage[]): string | undefined {
+  // Walk from the end to find the most-recent user message.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== 'user') continue;
+    if (typeof msg.content === 'string') return msg.content || undefined;
+    if (Array.isArray(msg.content)) {
+      for (const part of msg.content) {
+        if (
+          part != null &&
+          typeof part === 'object' &&
+          'type' in part &&
+          (part as { type: string }).type === 'text' &&
+          'text' in part &&
+          typeof (part as { text: string }).text === 'string'
+        ) {
+          const text = (part as { text: string }).text;
+          if (text) return text;
+        }
+      }
+    }
+  }
+  return undefined;
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -10,3 +10,16 @@ export const projects = sqliteTable('projects', {
 }, (t) => ({ ws: index('idx_projects_ws').on(t.workspaceId) }));
 
 export type ProjectRow = typeof projects.$inferSelect;
+
+export const chatSessions = sqliteTable('chat_sessions', {
+  id: text('id').primaryKey(),                    // sessionId (nanoid/uuid)
+  projectId: text('project_id').notNull(),
+  workspaceId: text('workspace_id').notNull(),    // Clerk userId (owner)
+  title: text('title').notNull().default('New chat'),
+  messageCount: integer('message_count').notNull().default(0),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  lastMessageAt: integer('last_message_at'),
+}, (t) => ({ proj: index('idx_chat_sessions_project').on(t.projectId, t.updatedAt) }));
+
+export type ChatSessionRow = typeof chatSessions.$inferSelect;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { getAvailableModels } from '@geometry-script/agent-core';
 import { ai } from './routes/ai';
 import { nodes } from './routes/nodes';
 import { projects } from './routes/projects';
+import { chatSessions } from './routes/chat-sessions';
 import { requireAuth } from './auth';
 import { EditorRoom } from './rooms/editor-room';
 import { Orchestrator } from './agents/orchestrator';
@@ -43,6 +44,10 @@ app.route('/nodes', nodes);
 
 app.use('/projects/*', requireAuth);
 app.route('/projects', projects);
+// Chat sessions are nested under /projects/:projectId/sessions.
+// Mounted separately (both under /projects) — Hono resolves sequentially,
+// and /:projectId/sessions does not conflict with the existing /:id routes.
+app.route('/projects', chatSessions);
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {

--- a/apps/api/src/routes/chat-sessions.ts
+++ b/apps/api/src/routes/chat-sessions.ts
@@ -1,0 +1,126 @@
+import { Hono } from 'hono';
+import { drizzle } from 'drizzle-orm/d1';
+import { eq, desc, and } from 'drizzle-orm';
+import type { Env } from '../index';
+import { chatSessions as chatSessionsTable, projects as projectsTable } from '../db/schema';
+
+export const chatSessions = new Hono<{ Bindings: Env; Variables: { userId: string } }>();
+
+/** Verify the caller owns the given project. Returns the project row or null. */
+async function getOwnedProject(db: ReturnType<typeof drizzle>, projectId: string, userId: string) {
+  const rows = await db
+    .select()
+    .from(projectsTable)
+    .where(and(eq(projectsTable.id, projectId), eq(projectsTable.workspaceId, userId)));
+  return rows[0] ?? null;
+}
+
+// GET /:projectId/sessions — list sessions for this project owned by the caller
+chatSessions.get('/:projectId/sessions', async (c) => {
+  const userId = c.get('userId');
+  const projectId = c.req.param('projectId');
+  const db = drizzle(c.env.DB);
+
+  const rows = await db
+    .select()
+    .from(chatSessionsTable)
+    .where(
+      and(
+        eq(chatSessionsTable.projectId, projectId),
+        eq(chatSessionsTable.workspaceId, userId),
+      ),
+    )
+    .orderBy(desc(chatSessionsTable.updatedAt));
+
+  return c.json({ success: true, data: rows });
+});
+
+// POST /:projectId/sessions — create a new session under a project
+chatSessions.post('/:projectId/sessions', async (c) => {
+  const userId = c.get('userId');
+  const projectId = c.req.param('projectId');
+  const db = drizzle(c.env.DB);
+
+  // Verify caller owns the project
+  const project = await getOwnedProject(db, projectId, userId);
+  if (!project) {
+    return c.json({ success: false, error: { message: 'Not found' } }, 404);
+  }
+
+  const body: { title?: string } = await c.req.json<{ title?: string }>().catch(() => ({}));
+  const now = Date.now();
+  const row = {
+    id: crypto.randomUUID(),
+    projectId,
+    workspaceId: userId,
+    title: body.title || 'New chat',
+    messageCount: 0,
+    createdAt: now,
+    updatedAt: now,
+    lastMessageAt: null as number | null,
+  };
+
+  await db.insert(chatSessionsTable).values(row);
+  return c.json({ success: true, data: row }, 201);
+});
+
+// PATCH /:projectId/sessions/:sessionId — rename a session
+chatSessions.patch('/:projectId/sessions/:sessionId', async (c) => {
+  const userId = c.get('userId');
+  const projectId = c.req.param('projectId');
+  const sessionId = c.req.param('sessionId');
+  const db = drizzle(c.env.DB);
+
+  const body: { title?: string } = await c.req.json<{ title?: string }>().catch(() => ({}));
+  if (!body.title) {
+    return c.json({ success: false, error: { message: 'title is required' } }, 400);
+  }
+
+  const now = Date.now();
+  const updated = await db
+    .update(chatSessionsTable)
+    .set({ title: body.title, updatedAt: now })
+    .where(
+      and(
+        eq(chatSessionsTable.id, sessionId),
+        eq(chatSessionsTable.projectId, projectId),
+        eq(chatSessionsTable.workspaceId, userId),
+      ),
+    )
+    .returning();
+
+  const row = updated[0];
+  if (!row) {
+    return c.json({ success: false, error: { message: 'Not found' } }, 404);
+  }
+
+  return c.json({ success: true, data: row });
+});
+
+// DELETE /:projectId/sessions/:sessionId — remove the D1 session index row.
+// NOTE: this only deletes the D1 index entry; the Orchestrator DO's message
+// history is stored separately and is NOT deleted here (acceptable for now —
+// DO cleanup can be added later when the session-storage contract is finalised).
+chatSessions.delete('/:projectId/sessions/:sessionId', async (c) => {
+  const userId = c.get('userId');
+  const projectId = c.req.param('projectId');
+  const sessionId = c.req.param('sessionId');
+  const db = drizzle(c.env.DB);
+
+  const deleted = await db
+    .delete(chatSessionsTable)
+    .where(
+      and(
+        eq(chatSessionsTable.id, sessionId),
+        eq(chatSessionsTable.projectId, projectId),
+        eq(chatSessionsTable.workspaceId, userId),
+      ),
+    )
+    .returning();
+
+  if (deleted.length === 0) {
+    return c.json({ success: false, error: { message: 'Not found' } }, 404);
+  }
+
+  return c.json({ success: true });
+});

--- a/apps/editor-web/app/components/AgentChatDock.tsx
+++ b/apps/editor-web/app/components/AgentChatDock.tsx
@@ -2,32 +2,34 @@
 
 /**
  * AgentChatDock — connects to the Orchestrator agent via WebSocket and
- * provides a chat interface for live scene editing.
+ * provides a chat interface for live scene editing, with per-session history.
  *
- * Uses the OFFICIAL chat hook (`useAgentChat` from `@cloudflare/ai-chat/react`)
- * on top of the raw `useAgent` connection. This replaces the previous
- * hand-rolled `cf_agent_*` wire protocol (which never produced a reply and
- * caused a reconnect loop in production).
+ * Session management:
+ *   Each chat session maps to a distinct DO instance named
+ *   `${projectId}:${sessionId}`.  Switching sessions changes `name` passed to
+ *   `useAgent`, which causes `usePartySocket` (inside `useAgent`) to reconnect
+ *   to the new instance.  `useAgentChat` is re-keyed via `id` so the SDK
+ *   treats it as a fresh chat and re-fetches messages from the new DO.
  *
- * How the per-turn context reaches the server:
- *   `useAgentChat({ body })` sends the returned record fields as extra keys in
- *   the chat request body. @cloudflare/think destructures
- *   `const { messages, clientTools, trigger, ...customBody } = body` and exposes
- *   `customBody` as `ctx.body` in `beforeTurn`. So `{ projectId, catalog }`
- *   below land at `ctx.body.projectId` / `ctx.body.catalog` exactly where
- *   `Orchestrator.beforeTurn` reads them. (projectId is also re-derived from the
- *   room token server-side for security; catalog is taken from the body.)
+ *   History loading: `getInitialMessages` is left **undefined** (the default),
+ *   which makes `useAgentChat` call the agent's `/get-messages` HTTP endpoint
+ *   on connect to load persisted history.  Passing `null` disables this; we now
+ *   omit the option entirely so the default loader runs.
  *
- * Connection auth: `useAgent({ query })` mints a short-lived room token and
- * attaches it as `?token=` on the WS upgrade, which `Orchestrator.onConnect`
- * validates. `query` (mintToken) is memoized so the socket does NOT reconnect
- * on every render.
- *
- * The editor reflects scene edits via C1 Room sync (separate connection); this
- * dock only handles the conversation.
+ * Render-loop safety (React #185):
+ *   - Session loading runs in a single `useEffect` keyed on
+ *     [projectId, getToken] — both stable references.
+ *   - `mintToken` / `buildBody` are memoized with `useCallback`.
+ *   - No `setMessages` or other unstable hook return in any effect dep array.
+ *   - Switcher callbacks are all `useCallback`-memoized.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useAuth } from '@clerk/clerk-react';
 import { useAgent } from 'agents/react';
 import { useAgentChat } from '@cloudflare/ai-chat/react';
@@ -38,9 +40,29 @@ import {
   type UIMessage,
   type UIMessagePart,
 } from 'ai';
-import { Loader2, Send, X, Sparkles, Bot, User, Wrench } from 'lucide-react';
+import {
+  Loader2,
+  Send,
+  X,
+  Sparkles,
+  Bot,
+  User,
+  Wrench,
+  ChevronDown,
+  Plus,
+  Pencil,
+  Trash2,
+  Check,
+} from 'lucide-react';
 import { apiBase } from '../lib/aiApi';
 import { buildCatalog } from '../lib/buildCatalog';
+import {
+  type ChatSession,
+  listSessions,
+  createSession,
+  renameSession,
+  deleteSession,
+} from '../lib/sessionsApi';
 
 interface AgentChatDockProps {
   projectId: string;
@@ -70,6 +92,22 @@ function deriveAgentEndpoint(): { host: string; protocol: 'ws' | 'wss' } {
 }
 
 // ---------------------------------------------------------------------------
+// Relative time helper
+// ---------------------------------------------------------------------------
+
+function relativeTime(iso?: string): string {
+  if (!iso) return '';
+  const ms = Date.now() - new Date(iso).getTime();
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+// ---------------------------------------------------------------------------
 // Part helpers (AI SDK v6 UIMessage parts)
 // ---------------------------------------------------------------------------
 
@@ -90,7 +128,7 @@ interface ToolChip {
   errored: boolean;
 }
 
-/** Extract tool-call parts (static `tool-<name>` and `dynamic-tool`) as chips. */
+/** Extract tool-call parts as chips. */
 function toolChips(parts: readonly AnyPart[]): ToolChip[] {
   const chips: ToolChip[] = [];
   for (let i = 0; i < parts.length; i++) {
@@ -190,6 +228,200 @@ function ChatMessage({
 }
 
 // ---------------------------------------------------------------------------
+// SessionSwitcher sub-component
+// ---------------------------------------------------------------------------
+
+interface SessionSwitcherProps {
+  sessions: ChatSession[];
+  activeSessionId: string | null;
+  onSelect: (sessionId: string) => void;
+  onNew: () => void;
+  onRename: (sessionId: string, newTitle: string) => void;
+  onDelete: (sessionId: string) => void;
+  loading: boolean;
+}
+
+function SessionSwitcher({
+  sessions,
+  activeSessionId,
+  onSelect,
+  onNew,
+  onRename,
+  onDelete,
+  loading,
+}: SessionSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setRenamingId(null);
+        setConfirmDeleteId(null);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  // Focus rename input when it appears
+  useEffect(() => {
+    if (renamingId) renameInputRef.current?.focus();
+  }, [renamingId]);
+
+  const activeSession = sessions.find((s) => s.id === activeSessionId);
+  const displayTitle = activeSession?.title || 'New chat';
+
+  function startRename(session: ChatSession) {
+    setRenamingId(session.id);
+    setRenameValue(session.title || '');
+    setConfirmDeleteId(null);
+  }
+
+  function commitRename(sessionId: string) {
+    const trimmed = renameValue.trim();
+    if (trimmed) onRename(sessionId, trimmed);
+    setRenamingId(null);
+  }
+
+  function handleRenameKey(
+    e: React.KeyboardEvent<HTMLInputElement>,
+    sessionId: string,
+  ) {
+    if (e.key === 'Enter') commitRename(sessionId);
+    if (e.key === 'Escape') setRenamingId(null);
+  }
+
+  function handleDelete(sessionId: string) {
+    if (confirmDeleteId === sessionId) {
+      onDelete(sessionId);
+      setConfirmDeleteId(null);
+      setOpen(false);
+    } else {
+      setConfirmDeleteId(sessionId);
+    }
+  }
+
+  return (
+    <div className="relative" ref={popoverRef}>
+      {/* Trigger button: shows active session title */}
+      <button
+        onClick={() => {
+          setOpen((v) => !v);
+          setRenamingId(null);
+          setConfirmDeleteId(null);
+        }}
+        className="flex items-center gap-1 max-w-[140px] px-2 py-1 rounded text-xs text-gray-300 hover:text-white hover:bg-gray-700/60 transition-colors truncate"
+        title={displayTitle}
+      >
+        <span className="truncate">{loading ? '…' : displayTitle}</span>
+        <ChevronDown className="w-3 h-3 flex-shrink-0 text-gray-500" />
+      </button>
+
+      {/* Popover */}
+      {open && (
+        <div className="absolute left-0 top-full mt-1 w-64 bg-gray-850 border border-gray-700 rounded-lg shadow-xl z-[80] overflow-hidden"
+          style={{ backgroundColor: '#131620' }}>
+          {/* New chat */}
+          <button
+            onClick={() => { onNew(); setOpen(false); }}
+            className="w-full flex items-center gap-2 px-3 py-2 text-xs text-purple-300 hover:bg-gray-700/60 transition-colors border-b border-gray-700/60"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            New chat
+          </button>
+
+          {/* Session list */}
+          <div className="max-h-60 overflow-y-auto">
+            {sessions.length === 0 && (
+              <p className="px-3 py-3 text-xs text-gray-500 text-center">No sessions yet</p>
+            )}
+            {sessions.map((session) => {
+              const isActive = session.id === activeSessionId;
+              const isRenaming = renamingId === session.id;
+              const isConfirmingDelete = confirmDeleteId === session.id;
+
+              return (
+                <div
+                  key={session.id}
+                  className={`flex items-center gap-1 px-2 py-1.5 group hover:bg-gray-700/40 transition-colors ${
+                    isActive ? 'bg-gray-700/30' : ''
+                  }`}
+                >
+                  {isRenaming ? (
+                    <div className="flex-1 flex items-center gap-1">
+                      <input
+                        ref={renameInputRef}
+                        value={renameValue}
+                        onChange={(e) => setRenameValue(e.target.value)}
+                        onKeyDown={(e) => handleRenameKey(e, session.id)}
+                        onBlur={() => commitRename(session.id)}
+                        className="flex-1 bg-gray-700 text-white text-xs rounded px-2 py-0.5 border border-purple-500/60 focus:outline-none"
+                        maxLength={80}
+                      />
+                      <button
+                        onMouseDown={() => commitRename(session.id)}
+                        className="text-green-400 hover:text-green-300 p-0.5"
+                      >
+                        <Check className="w-3 h-3" />
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => { onSelect(session.id); setOpen(false); }}
+                        className="flex-1 text-left min-w-0"
+                      >
+                        <p className={`text-xs truncate ${isActive ? 'text-white font-medium' : 'text-gray-300'}`}>
+                          {session.title || 'Untitled chat'}
+                        </p>
+                        <p className="text-[10px] text-gray-500">
+                          {relativeTime(session.lastMessageAt || session.updatedAt)}
+                          {session.messageCount ? ` · ${session.messageCount} msg` : ''}
+                        </p>
+                      </button>
+
+                      {/* Actions (visible on hover or active) */}
+                      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+                        <button
+                          onClick={(e) => { e.stopPropagation(); startRename(session); }}
+                          className="p-1 text-gray-400 hover:text-white rounded transition-colors"
+                          title="Rename"
+                        >
+                          <Pencil className="w-3 h-3" />
+                        </button>
+                        <button
+                          onClick={(e) => { e.stopPropagation(); handleDelete(session.id); }}
+                          className={`p-1 rounded transition-colors ${
+                            isConfirmingDelete
+                              ? 'text-red-400 hover:text-red-300'
+                              : 'text-gray-400 hover:text-red-400'
+                          }`}
+                          title={isConfirmingDelete ? 'Click again to confirm delete' : 'Delete'}
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // AgentChatDock
 // ---------------------------------------------------------------------------
 
@@ -200,40 +432,90 @@ export function AgentChatDock({ projectId, open, onClose }: AgentChatDockProps) 
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
+  // --- Session state ---
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+
   const { host, protocol } = deriveAgentEndpoint();
 
   /**
-   * Mint a room-token for the orchestrator connection. Mirrors roomClient.ts
-   * exactly (same endpoint, same format). Memoized on [projectId, getToken] so
-   * the WebSocket does NOT reconnect on every render — this stable identity
-   * (plus `queryDeps: [projectId]`) is what stops the reconnect loop.
+   * Load sessions on open. If none exist, auto-create one.
+   * Deps: [projectId, getToken] — both stable refs, no loop risk.
    */
-  const mintToken = useCallback(async (): Promise<Record<string, string | null>> => {
-    if (!projectId) return { token: null };
-    try {
-      const clerkToken = await getToken();
-      const res = await fetch(`${apiBase}/projects/${projectId}/room-token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(clerkToken ? { Authorization: `Bearer ${clerkToken}` } : {}),
-        },
-      });
-      if (!res.ok) {
-        console.error('[agent-chat] room-token request failed', res.status);
-        return { token: null };
+  useEffect(() => {
+    if (!open || !projectId) return;
+
+    let cancelled = false;
+    setSessionsLoading(true);
+
+    async function load() {
+      try {
+        let list = await listSessions(projectId, getToken);
+        if (cancelled) return;
+
+        if (list.length === 0) {
+          const fresh = await createSession(projectId, undefined, getToken);
+          if (cancelled) return;
+          list = [fresh];
+        }
+
+        setSessions(list);
+        // Default to the most recent session (list is newest-first from API)
+        setActiveSessionId((prev) => prev ?? list[0].id);
+      } catch (err) {
+        console.error('[agent-chat] failed to load sessions', err);
+      } finally {
+        if (!cancelled) setSessionsLoading(false);
       }
-      const json = (await res.json()) as { data?: { token?: string } };
-      return { token: json?.data?.token ?? null };
-    } catch (err) {
-      console.error('[agent-chat] failed to mint token', err);
-      return { token: null };
     }
-  }, [projectId, getToken]);
+
+    void load();
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, projectId]); // getToken is stable from Clerk; intentionally omitted to avoid churn
+
+  // The DO instance name is scoped per session.
+  // Changing activeSessionId changes `name`, which causes useAgent/usePartySocket
+  // to close the old WS and open a new one to the correct DO instance.
+  const agentName = activeSessionId
+    ? `${projectId}:${activeSessionId}`
+    : (projectId || 'disabled');
 
   /**
-   * Per-turn body fields the server reads via `ctx.body`. Stable callback so the
-   * chat hook does not churn. `buildCatalog()` is evaluated lazily on each send.
+   * Mint a room-token for the orchestrator connection.
+   * The room-token is project-scoped (sessionId is not in the token);
+   * the orchestrator validates the projectId segment of the DO name.
+   * Memoized on [projectId, getToken] — stable, no reconnect churn.
+   */
+  const mintToken = useCallback(
+    async (): Promise<Record<string, string | null>> => {
+      if (!projectId) return { token: null };
+      try {
+        const clerkToken = await getToken();
+        const res = await fetch(`${apiBase}/projects/${projectId}/room-token`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(clerkToken ? { Authorization: `Bearer ${clerkToken}` } : {}),
+          },
+        });
+        if (!res.ok) {
+          console.error('[agent-chat] room-token request failed', res.status);
+          return { token: null };
+        }
+        const json = (await res.json()) as { data?: { token?: string } };
+        return { token: json?.data?.token ?? null };
+      } catch (err) {
+        console.error('[agent-chat] failed to mint token', err);
+        return { token: null };
+      }
+    },
+    [projectId, getToken],
+  );
+
+  /**
+   * Per-turn body fields the server reads via `ctx.body`.
    */
   const buildBody = useCallback(
     () => ({ projectId, catalog: buildCatalog() }),
@@ -241,19 +523,25 @@ export function AgentChatDock({ projectId, open, onClose }: AgentChatDockProps) 
   );
 
   /**
-   * useAgent opens a persistent WebSocket to
-   *   {protocol}://{host}/agents/orchestrator/{projectId}
-   * One orchestrator instance per project (name = projectId).
+   * useAgent opens a persistent WebSocket to:
+   *   {protocol}://{host}/agents/orchestrator/{projectId}:{sessionId}
+   *
+   * When `name` (agentName) changes — i.e. session switches — usePartySocket
+   * inside useAgent tears down the old socket and opens a new one.
+   *
+   * queryDeps includes agentName so a fresh token is minted for each new
+   * session connection (same project token is valid, but we re-mint to be safe
+   * with TTL — the token is project-scoped so the server accepts it for any
+   * session under that project).
    */
   const agent = useAgent({
     agent: 'orchestrator',
-    name: projectId || 'disabled',
+    name: agentName,
     host,
     protocol,
-    enabled: open && Boolean(projectId),
+    enabled: open && Boolean(projectId) && Boolean(activeSessionId),
     query: mintToken,
-    queryDeps: [projectId],
-    // Refresh well before the server's 120s token TTL.
+    queryDeps: [agentName],
     cacheTtl: 90_000,
     onOpen: () => setConnected(true),
     onClose: () => setConnected(false),
@@ -261,20 +549,22 @@ export function AgentChatDock({ projectId, open, onClose }: AgentChatDockProps) 
   });
 
   /**
-   * Official chat hook. Drives the standard agents chat wire protocol over the
-   * `agent` socket: sends user turns, parses streamed chunks into v6 UIMessages
-   * with `parts`, and exposes `status`/`isStreaming` + `sendMessage`.
+   * Official chat hook. `id` is session-scoped so the hook re-initialises its
+   * internal message state when the session changes.
+   *
+   * `getInitialMessages` is **not passed** (undefined = default), which causes
+   * the hook to call the agent's /get-messages HTTP endpoint on connect to load
+   * persisted history from the DO's Think storage.  Passing `null` would
+   * disable history loading — we must NOT do that here.
    */
   const chat = useAgentChat<unknown, UIMessage>({
     agent,
-    id: projectId || 'disabled',
-    // Don't fetch persisted history over HTTP; this dock is conversation-only.
-    getInitialMessages: null,
+    id: agentName,
+    // getInitialMessages intentionally omitted → default loader fetches history
     body: buildBody,
   });
 
   const { messages, sendMessage, status } = chat;
-  // True from the moment a turn is submitted until the stream ends.
   const busy = status === 'submitted' || status === 'streaming' || chat.isStreaming;
 
   // Auto-scroll to bottom when messages change.
@@ -285,11 +575,70 @@ export function AgentChatDock({ projectId, open, onClose }: AgentChatDockProps) 
     });
   }, [messages]);
 
-  // NOTE: no reset-on-close effect here. The parent only mounts this component
-  // while open, so closing unmounts it and clears all state automatically.
-  // (A `useEffect(... setMessages([]) ..., [open, setMessages])` here caused
-  // React error #185 — an infinite setState loop — when `setMessages` was not
-  // referentially stable.)
+  // Reset connection state when the session changes so the dot doesn't stay
+  // green momentarily after reconnect begins.
+  useEffect(() => {
+    setConnected(false);
+  }, [agentName]);
+
+  // -------------------------------------------------------------------------
+  // Session management callbacks
+  // -------------------------------------------------------------------------
+
+  const handleNewSession = useCallback(async () => {
+    try {
+      const session = await createSession(projectId, undefined, getToken);
+      setSessions((prev) => [session, ...prev]);
+      setActiveSessionId(session.id);
+    } catch (err) {
+      console.error('[agent-chat] failed to create session', err);
+    }
+  }, [projectId, getToken]);
+
+  const handleSelectSession = useCallback((sessionId: string) => {
+    setActiveSessionId(sessionId);
+  }, []);
+
+  const handleRenameSession = useCallback(
+    async (sessionId: string, title: string) => {
+      try {
+        const updated = await renameSession(projectId, sessionId, title, getToken);
+        setSessions((prev) =>
+          prev.map((s) => (s.id === sessionId ? { ...s, title: updated.title } : s)),
+        );
+      } catch (err) {
+        console.error('[agent-chat] failed to rename session', err);
+      }
+    },
+    [projectId, getToken],
+  );
+
+  const handleDeleteSession = useCallback(
+    async (sessionId: string) => {
+      try {
+        await deleteSession(projectId, sessionId, getToken);
+        setSessions((prev) => {
+          const remaining = prev.filter((s) => s.id !== sessionId);
+          // If we deleted the active session, switch to another or create one
+          if (activeSessionId === sessionId) {
+            if (remaining.length > 0) {
+              setActiveSessionId(remaining[0].id);
+            } else {
+              // Create a fresh session asynchronously
+              void createSession(projectId, undefined, getToken).then((fresh) => {
+                setSessions([fresh]);
+                setActiveSessionId(fresh.id);
+              });
+            }
+          }
+          return remaining;
+        });
+      } catch (err) {
+        console.error('[agent-chat] failed to delete session', err);
+      }
+    },
+    [projectId, getToken, activeSessionId],
+  );
 
   // -------------------------------------------------------------------------
   // Send a message turn
@@ -314,9 +663,6 @@ export function AgentChatDock({ projectId, open, onClose }: AgentChatDockProps) 
   // -------------------------------------------------------------------------
 
   if (!open) return null;
-
-  // No active project → render nothing meaningful (parent already guards on
-  // projectId, but keep the dock a no-op if it's ever mounted without one).
   if (!projectId) return null;
 
   const lastIsAssistant =
@@ -327,18 +673,28 @@ export function AgentChatDock({ projectId, open, onClose }: AgentChatDockProps) 
     <div className="fixed right-4 bottom-20 w-96 h-[580px] bg-gray-900 border border-gray-700 rounded-xl shadow-2xl z-[70] flex flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 bg-gray-900 border-b border-gray-700 flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <Sparkles className="w-4 h-4 text-purple-400" />
-          <span className="text-white font-semibold text-sm">Agent</span>
+        <div className="flex items-center gap-2 min-w-0">
+          <Sparkles className="w-4 h-4 text-purple-400 flex-shrink-0" />
+          <span className="text-white font-semibold text-sm flex-shrink-0">Agent</span>
           <span
-            className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-green-400' : 'bg-gray-600'}`}
+            className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${connected ? 'bg-green-400' : 'bg-gray-600'}`}
             title={connected ? 'Connected' : 'Connecting…'}
           />
-          {busy && <Loader2 className="w-3 h-3 text-purple-400 animate-spin" />}
+          {/* Session switcher */}
+          <SessionSwitcher
+            sessions={sessions}
+            activeSessionId={activeSessionId}
+            onSelect={handleSelectSession}
+            onNew={() => void handleNewSession()}
+            onRename={(id, title) => void handleRenameSession(id, title)}
+            onDelete={(id) => void handleDeleteSession(id)}
+            loading={sessionsLoading}
+          />
+          {busy && <Loader2 className="w-3 h-3 text-purple-400 animate-spin flex-shrink-0" />}
         </div>
         <button
           onClick={onClose}
-          className="text-gray-400 hover:text-white transition-colors p-1 rounded"
+          className="text-gray-400 hover:text-white transition-colors p-1 rounded flex-shrink-0"
           aria-label="Close agent chat"
         >
           <X className="w-4 h-4" />

--- a/apps/editor-web/app/lib/sessionsApi.ts
+++ b/apps/editor-web/app/lib/sessionsApi.ts
@@ -1,0 +1,88 @@
+import { apiBase } from './aiApi';
+
+export interface ChatSession {
+  id: string;
+  projectId: string;
+  workspaceId?: string;
+  title?: string;
+  messageCount?: number;
+  createdAt?: string;
+  updatedAt?: string;
+  lastMessageAt?: string;
+}
+
+type GetToken = () => Promise<string | null>;
+
+function authHeaders(token: string | null): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export async function listSessions(
+  projectId: string,
+  getToken: GetToken,
+): Promise<ChatSession[]> {
+  const token = await getToken();
+  const res = await fetch(`${apiBase}/projects/${projectId}/sessions`, {
+    headers: authHeaders(token),
+  });
+  if (!res.ok) throw new Error(`list sessions failed (${res.status})`);
+  const json = (await res.json()) as { data?: ChatSession[] };
+  return json?.data ?? [];
+}
+
+export async function createSession(
+  projectId: string,
+  title: string | undefined,
+  getToken: GetToken,
+): Promise<ChatSession> {
+  const token = await getToken();
+  const res = await fetch(`${apiBase}/projects/${projectId}/sessions`, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify(title ? { title } : {}),
+  });
+  if (!res.ok) throw new Error(`create session failed (${res.status})`);
+  const json = (await res.json()) as { data?: ChatSession };
+  if (!json?.data?.id) throw new Error('create session returned no id');
+  return json.data;
+}
+
+export async function renameSession(
+  projectId: string,
+  sessionId: string,
+  title: string,
+  getToken: GetToken,
+): Promise<ChatSession> {
+  const token = await getToken();
+  const res = await fetch(
+    `${apiBase}/projects/${projectId}/sessions/${sessionId}`,
+    {
+      method: 'PATCH',
+      headers: authHeaders(token),
+      body: JSON.stringify({ title }),
+    },
+  );
+  if (!res.ok) throw new Error(`rename session failed (${res.status})`);
+  const json = (await res.json()) as { data?: ChatSession };
+  if (!json?.data) throw new Error('rename session returned no data');
+  return json.data;
+}
+
+export async function deleteSession(
+  projectId: string,
+  sessionId: string,
+  getToken: GetToken,
+): Promise<void> {
+  const token = await getToken();
+  const res = await fetch(
+    `${apiBase}/projects/${projectId}/sessions/${sessionId}`,
+    {
+      method: 'DELETE',
+      headers: authHeaders(token),
+    },
+  );
+  if (!res.ok) throw new Error(`delete session failed (${res.status})`);
+}


### PR DESCRIPTION
## Summary
Multiple chat sessions per project with persisted history.

- **D1 `chat_sessions`** index (id, projectId, workspaceId, title, messageCount, timestamps) + per-project routes (list/create/rename/delete, Clerk-auth + ownership).
- **Orchestrator per-session**: instance name `${projectId}:${sessionId}`; validates the projectId segment against the room token; upserts the D1 index per turn (auto-title from first message) via `beforeTurn` + `ctx.waitUntil`.
- **Dock**: session switcher (new/switch/rename/delete) + persisted history load (default `getInitialMessages` → `/get-messages`).
- Design: DO holds full messages (durable); D1 is the queryable session index (no message duplication) — matches ipio.

## Test Plan
- [x] check-types + build green; migration applied local + remote
- [x] Deployed api + SPA; sessions endpoint 401 unauth
- [ ] Owner signed-in: multi-session create/switch/rename, history persists across reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)